### PR TITLE
Convert desktop FatBit app to Flask web

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,34 @@
-# FatBit
+# FatBit Web
 
-FatBit is a simple PyQt5 application for tracking weight and body fat data.
-It reads Fitbit JSON exports and stores entries in a local SQLite database. The
-application provides basic plots (weight, BMI, lean mass and body fat%) and a
-convenient editor for manual updates.
+FatBit Web is a lightweight Flask application for tracking your weight and body fat measurements. Data is stored in a local SQLite database and visualised using Matplotlib. The interface lets you add, edit and delete entries as well as view basic plots and set your height for BMI calculations.
 
+## Setup
+
+1. **Install Python dependencies**
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. **Run the application**
+   ```bash
+   python webapp.py
+   ```
+   The app runs on `http://127.0.0.1:5000/` by default.
+
+## Deployment
+
+For production deployment you can use any WSGI server such as `gunicorn`:
+
+```bash
+pip install gunicorn
+gunicorn -w 4 webapp:app
+```
+
+Ensure the `weight_data.db` file is persisted between runs.
+
+## Usage
+
+- Navigate to the **Entries** page to add new measurements.
+- Use **Plots** to see weight, BMI and other charts.
+- Set your height in **Settings** to calculate BMI automatically.
+
+FatBit Web replaces the old PyQt desktop application with a more accessible web interface.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+pandas
+matplotlib

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>FatBit Web</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  </head>
+  <body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
+      <div class="container-fluid">
+        <a class="navbar-brand" href="{{ url_for('index') }}">FatBit</a>
+        <div class="collapse navbar-collapse">
+          <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+            <li class="nav-item"><a class="nav-link" href="{{ url_for('index') }}">Entries</a></li>
+            <li class="nav-item"><a class="nav-link" href="{{ url_for('plots') }}">Plots</a></li>
+            <li class="nav-item"><a class="nav-link" href="{{ url_for('settings') }}">Settings</a></li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+    <div class="container">
+      {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+          {% for category, message in messages %}
+            <div class="alert alert-{{ category }}" role="alert">{{ message }}</div>
+          {% endfor %}
+        {% endif %}
+      {% endwith %}
+      {% block content %}{% endblock %}
+    </div>
+  </body>
+</html>

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -1,0 +1,34 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Edit Entry</h2>
+<form method="post" class="row g-3">
+  <div class="col-md-2">
+    <label class="form-label">Log ID</label>
+    <input type="text" class="form-control" name="logId" value="{{ entry.logId }}">
+  </div>
+  <div class="col-md-2">
+    <label class="form-label">Date</label>
+    <input type="text" class="form-control" name="date" value="{{ entry.date }}" required>
+  </div>
+  <div class="col-md-2">
+    <label class="form-label">Time</label>
+    <input type="text" class="form-control" name="time" value="{{ entry.time }}" required>
+  </div>
+  <div class="col-md-2">
+    <label class="form-label">Weight (kg)</label>
+    <input type="number" step="0.01" class="form-control" name="weight_kg" value="{{ entry.weight_kg }}" required>
+  </div>
+  <div class="col-md-2">
+    <label class="form-label">Body Fat (%)</label>
+    <input type="number" step="0.01" class="form-control" name="fat_percent" value="{{ entry.fat_percent }}">
+  </div>
+  <div class="col-md-2">
+    <label class="form-label">Source</label>
+    <input type="text" class="form-control" name="source" value="{{ entry.source }}">
+  </div>
+  <div class="col-12">
+    <button type="submit" class="btn btn-primary">Save</button>
+    <a href="{{ url_for('index') }}" class="btn btn-secondary">Cancel</a>
+  </div>
+</form>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,47 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Entries</h2>
+<form action="{{ url_for('add_entry') }}" method="post" class="row g-3 mb-3">
+  <div class="col-auto">
+    <input type="text" class="form-control" name="logId" placeholder="Log ID">
+  </div>
+  <div class="col-auto">
+    <input type="text" class="form-control" name="date" placeholder="MM/DD/YY" required>
+  </div>
+  <div class="col-auto">
+    <input type="text" class="form-control" name="time" placeholder="HH:MM:SS" required>
+  </div>
+  <div class="col-auto">
+    <input type="number" step="0.01" class="form-control" name="weight_kg" placeholder="Weight (kg)" required>
+  </div>
+  <div class="col-auto">
+    <input type="number" step="0.01" class="form-control" name="fat_percent" placeholder="Body Fat (%)">
+  </div>
+  <div class="col-auto">
+    <input type="text" class="form-control" name="source" placeholder="Source">
+  </div>
+  <div class="col-auto">
+    <button type="submit" class="btn btn-primary mb-3">Add</button>
+  </div>
+</form>
+{{ tables|safe }}
+<script>
+// Add delete buttons after table is rendered
+const table = document.querySelector('table');
+if (table) {
+  const header = table.querySelector('tr');
+  const th = document.createElement('th');
+  th.innerText = 'Actions';
+  header.appendChild(th);
+  Array.from(table.querySelectorAll('tr')).slice(1).forEach(row => {
+    const id = row.children[0].innerText;
+    const cell = document.createElement('td');
+    cell.innerHTML = `<form action="/delete/${id}" method="post" style="display:inline-block">
+                        <button class="btn btn-danger btn-sm">Delete</button>
+                      </form>
+                      <a class="btn btn-secondary btn-sm" href="/edit/${id}">Edit</a>`;
+    row.appendChild(cell);
+  });
+}
+</script>
+{% endblock %}

--- a/templates/plots.html
+++ b/templates/plots.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Plots</h2>
+<div class="row">
+  <div class="col-md-6 mb-4">
+    <h5>Weight (kg) over Time</h5>
+    <img src="{{ url_for('plot_png', plot_type='weight') }}" class="img-fluid" />
+  </div>
+  <div class="col-md-6 mb-4">
+    <h5>BMI over Time</h5>
+    <img src="{{ url_for('plot_png', plot_type='bmi') }}" class="img-fluid" />
+  </div>
+  <div class="col-md-6 mb-4">
+    <h5>Lean Mass (kg) over Time</h5>
+    <img src="{{ url_for('plot_png', plot_type='lean') }}" class="img-fluid" />
+  </div>
+  <div class="col-md-6 mb-4">
+    <h5>Body Fat (%) over Time</h5>
+    <img src="{{ url_for('plot_png', plot_type='fat') }}" class="img-fluid" />
+  </div>
+</div>
+{% endblock %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Settings</h2>
+<form method="post" class="row g-3">
+  <div class="col-md-4">
+    <label class="form-label">Height (m)</label>
+    <input type="number" step="0.01" class="form-control" name="height" value="{{ height or '' }}" required>
+  </div>
+  <div class="col-12">
+    <button type="submit" class="btn btn-primary">Save</button>
+    <a href="{{ url_for('index') }}" class="btn btn-secondary">Back</a>
+  </div>
+</form>
+{% endblock %}

--- a/webapp.py
+++ b/webapp.py
@@ -1,0 +1,212 @@
+from flask import Flask, render_template, request, redirect, url_for, flash
+import os
+import pandas as pd
+import matplotlib
+matplotlib.use('Agg')  # Use non-GUI backend for matplotlib
+import matplotlib.pyplot as plt
+import sqlite3
+import datetime
+
+# ---------------------------
+# Data persistence utilities
+# ---------------------------
+class DataManager:
+    """Lightweight wrapper around SQLite for storing weight entries."""
+
+    def __init__(self, db_file="weight_data.db"):
+        self.db_file = db_file
+        self.conn = sqlite3.connect(self.db_file, check_same_thread=False)
+        self.create_table()
+        self.height = None
+
+    def create_table(self):
+        """Create the entries table if needed."""
+        query = """
+        CREATE TABLE IF NOT EXISTS entries (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            logId INTEGER,
+            date TEXT,
+            time TEXT,
+            timestamp TEXT,
+            weight_kg REAL,
+            fat_percent REAL,
+            bmi REAL,
+            source TEXT
+        )
+        """
+        self.conn.execute(query)
+        self.conn.commit()
+
+    def add_entry(self, entry):
+        """Insert a new weight entry."""
+        query = """
+        INSERT INTO entries (logId, date, time, timestamp, weight_kg, fat_percent, bmi, source)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """
+        dt_str = f"{entry['date']} {entry['time']}"
+        try:
+            dt_obj = datetime.datetime.strptime(dt_str, "%m/%d/%y %H:%M:%S")
+            timestamp = dt_obj.strftime("%Y-%m-%d %H:%M:%S")
+        except Exception:
+            timestamp = dt_str
+        self.conn.execute(query, (
+            entry.get("logId"),
+            entry.get("date"),
+            entry.get("time"),
+            timestamp,
+            entry.get("weight_kg"),
+            entry.get("fat_percent"),
+            entry.get("bmi"),
+            entry.get("source")
+        ))
+        self.conn.commit()
+
+    def get_all_entries(self):
+        """Return all entries as a pandas DataFrame."""
+        return pd.read_sql_query("SELECT * FROM entries ORDER BY timestamp", self.conn)
+
+    def update_entry(self, entry_id, updated_entry):
+        """Update an existing entry."""
+        query = """
+        UPDATE entries
+        SET logId=?, date=?, time=?, timestamp=?, weight_kg=?, fat_percent=?, bmi=?, source=?
+        WHERE id=?
+        """
+        dt_str = f"{updated_entry['date']} {updated_entry['time']}"
+        try:
+            dt_obj = datetime.datetime.strptime(dt_str, "%m/%d/%y %H:%M:%S")
+            timestamp = dt_obj.strftime("%Y-%m-%d %H:%M:%S")
+        except Exception:
+            timestamp = dt_str
+        self.conn.execute(query, (
+            updated_entry.get("logId"),
+            updated_entry.get("date"),
+            updated_entry.get("time"),
+            timestamp,
+            updated_entry.get("weight_kg"),
+            updated_entry.get("fat_percent"),
+            updated_entry.get("bmi"),
+            updated_entry.get("source"),
+            entry_id
+        ))
+        self.conn.commit()
+
+    def delete_entry(self, entry_id):
+        """Remove an entry from the database."""
+        self.conn.execute("DELETE FROM entries WHERE id=?", (entry_id,))
+        self.conn.commit()
+
+# -----------------------
+# Flask application setup
+# -----------------------
+app = Flask(__name__)
+app.config['SECRET_KEY'] = 'change-me'
+
+# Use a global DataManager instance
+data_manager = DataManager()
+
+@app.route('/')
+def index():
+    """Display all entries and allow basic operations."""
+    df = data_manager.get_all_entries()
+    return render_template('index.html', tables=[df.to_html(classes='table table-striped', index=False)], titles=df.columns.values)
+
+@app.route('/add', methods=['POST'])
+def add_entry():
+    """Add a new weight entry from the submitted form."""
+    entry = {
+        'logId': request.form.get('logId', type=int),
+        'date': request.form['date'],
+        'time': request.form['time'],
+        'weight_kg': request.form.get('weight_kg', type=float),
+        'fat_percent': request.form.get('fat_percent', type=float),
+        'bmi': None,
+        'source': request.form.get('source', 'Manual')
+    }
+    if data_manager.height:
+        entry['bmi'] = entry['weight_kg'] / (data_manager.height ** 2)
+    data_manager.add_entry(entry)
+    flash('Entry added', 'success')
+    return redirect(url_for('index'))
+
+@app.route('/delete/<int:entry_id>', methods=['POST'])
+def delete_entry(entry_id):
+    """Delete an entry by ID."""
+    data_manager.delete_entry(entry_id)
+    flash('Entry deleted', 'info')
+    return redirect(url_for('index'))
+
+@app.route('/edit/<int:entry_id>', methods=['GET', 'POST'])
+def edit_entry(entry_id):
+    """Edit an existing entry."""
+    df = data_manager.get_all_entries()
+    row = df[df['id'] == entry_id].iloc[0]
+    if request.method == 'POST':
+        updated = {
+            'logId': request.form.get('logId', type=int),
+            'date': request.form['date'],
+            'time': request.form['time'],
+            'weight_kg': request.form.get('weight_kg', type=float),
+            'fat_percent': request.form.get('fat_percent', type=float),
+            'bmi': None,
+            'source': request.form.get('source', 'Manual')
+        }
+        if data_manager.height:
+            updated['bmi'] = updated['weight_kg'] / (data_manager.height ** 2)
+        data_manager.update_entry(entry_id, updated)
+        flash('Entry updated', 'success')
+        return redirect(url_for('index'))
+    return render_template('edit.html', entry=row)
+
+@app.route('/settings', methods=['GET', 'POST'])
+def settings():
+    """Manage user settings such as height used for BMI."""
+    if request.method == 'POST':
+        try:
+            data_manager.height = float(request.form['height'])
+            flash('Height saved', 'success')
+        except ValueError:
+            flash('Invalid height', 'danger')
+    return render_template('settings.html', height=data_manager.height)
+
+@app.route('/plot/<plot_type>.png')
+def plot_png(plot_type):
+    """Generate matplotlib plot based on selected type."""
+    df = data_manager.get_all_entries()
+    df['timestamp'] = pd.to_datetime(df['timestamp'])
+
+    fig, ax = plt.subplots()
+    if plot_type == 'weight':
+        ax.plot(df['timestamp'], df['weight_kg'], marker='o')
+        ax.set_ylabel('Weight (kg)')
+    elif plot_type == 'bmi':
+        ax.plot(df['timestamp'], df['bmi'], marker='o')
+        ax.set_ylabel('BMI')
+    elif plot_type == 'lean':
+        lean = df['weight_kg'] * (1 - df['fat_percent'] / 100)
+        ax.plot(df['timestamp'], lean, marker='o')
+        ax.set_ylabel('Lean Mass (kg)')
+    elif plot_type == 'fat':
+        ax.plot(df['timestamp'], df['fat_percent'], marker='o')
+        ax.set_ylabel('Body Fat (%)')
+    ax.set_xlabel('Time')
+    ax.set_title(plot_type.title())
+    fig.autofmt_xdate()
+
+    # Render plot to PNG image in memory
+    import io
+    output = io.BytesIO()
+    plt.savefig(output, format='png')
+    plt.close(fig)
+    output.seek(0)
+    from flask import send_file
+    return send_file(output, mimetype='image/png')
+
+@app.route('/plots')
+def plots():
+    """Page with all plots displayed."""
+    return render_template('plots.html')
+
+if __name__ == '__main__':
+    # Debug mode should be disabled in production
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- replace PyQt UI with a Flask based web app
- add Bootstrap styled HTML templates
- document setup and deployment steps in README
- add `requirements.txt` for easy installation

## Testing
- `pip install -q -r requirements.txt`
- `python -m py_compile webapp.py`
- `python webapp.py` *(launched and terminated)*

------
https://chatgpt.com/codex/tasks/task_e_6884a09803b08328bf9e9a489e0cc723