### PR TITLE
Update README for Windows users

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ pip install gunicorn
 gunicorn -w 4 webapp:app
 ```
 
+Gunicorn requires a Unix-like environment. On Windows you can either run the
+application directly with `python webapp.py` or use a WSGI server that supports
+Windows, such as `waitress`.
+
 Ensure the `weight_data.db` file is persisted between runs.
 
 ## Usage


### PR DESCRIPTION
## Summary
- clarify that gunicorn requires Unix and offer Windows alternatives

## Testing
- `python -m py_compile FatBit.py webapp.py`


------
https://chatgpt.com/codex/tasks/task_e_6884a7b7fc0c8328b1509aec9e2a8cd4