### PR TITLE
Fix table rendering and add Fitbit export docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,17 @@ Ensure the `weight_data.db` file is persisted between runs.
 - Use **Plots** to see weight, BMI and other charts.
 - Set your height in **Settings** to calculate BMI automatically.
 
+## Getting your Fitbit data from Google
+
+If you want to import historical Fitbit measurements, Google provides an export through **Google Takeout**.
+
+1. Visit [Google Takeout](https://takeout.google.com/).
+2. Deselect everything and then check **Fitbit**.
+3. Follow the prompts to create your export. Google will email you a link when it is ready.
+4. Download the exported ZIP and extract it. The weight log is located in `Takeout/Fitbit/Weight/Weight.csv`.
+5. Import the CSV contents into FatBit using the entries page or by inserting the rows into the SQLite database.
+
+For more details see [Google's help article](https://support.google.com/fitbit/answer/12554576).
+
+
 FatBit Web replaces the old PyQt desktop application with a more accessible web interface.

--- a/templates/index.html
+++ b/templates/index.html
@@ -24,7 +24,7 @@
     <button type="submit" class="btn btn-primary mb-3">Add</button>
   </div>
 </form>
-{{ tables|safe }}
+{{ table|safe }}
 <script>
 // Add delete buttons after table is rendered
 const table = document.querySelector('table');

--- a/webapp.py
+++ b/webapp.py
@@ -109,7 +109,10 @@ data_manager = DataManager()
 def index():
     """Display all entries and allow basic operations."""
     df = data_manager.get_all_entries()
-    return render_template('index.html', tables=[df.to_html(classes='table table-striped', index=False)], titles=df.columns.values)
+    # Convert the data frame to an HTML table string. This string will be
+    # injected directly into the template so the browser renders a nice table.
+    table_html = df.to_html(classes='table table-striped', index=False)
+    return render_template('index.html', table=table_html, titles=df.columns.values)
 
 @app.route('/add', methods=['POST'])
 def add_entry():


### PR DESCRIPTION
## Summary
- show entries table using a simple HTML string to avoid formatting issues
- update entry template to use `table` variable
- document how to obtain Fitbit data from Google Takeout

## Testing
- `python -m py_compile webapp.py FatBit.py`
- `python webapp.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install -r requirements.txt`
- `python webapp.py`

------
https://chatgpt.com/codex/tasks/task_e_6884a83184e0832882ab1aaf81ac6bd7