### PR TITLE
Add Raspberry Pi hosting script

### DIFF
--- a/run_rpi.sh
+++ b/run_rpi.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# run_rpi.sh - Convenience script to host the FatBit web app on a Raspberry Pi.
+#
+# Usage: ./run_rpi.sh [PORT]
+# If PORT is not provided, the app runs on 5000 by default.
+#
+# The script installs required Python packages (for the current user) and
+# launches the Flask development server bound to all network interfaces so the
+# application is reachable over the local network.
+#
+# Note: For production deployment you should use a WSGI server like gunicorn.
+
+set -e
+
+# Read the desired port from the first argument, defaulting to 5000 if omitted
+PORT=${1:-5000}
+
+# Install Python dependencies
+pip install --user -r requirements.txt
+
+# Tell Flask which application to run
+export FLASK_APP=webapp
+
+# Start the Flask development server accessible from other machines
+flask run --host 0.0.0.0 --port "$PORT"


### PR DESCRIPTION
## Summary
- add `run_rpi.sh` helper for hosting the Flask app on a Raspberry Pi

## Testing
- `bash -n run_rpi.sh`


------
https://chatgpt.com/codex/tasks/task_e_6884b2fb09448328be0f95002135df34