### PR TITLE
Add Raspberry Pi hosting helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,13 @@ For more details see [Google's help article](https://support.google.com/fitbit/a
 
 
 FatBit Web replaces the old PyQt desktop application with a more accessible web interface.
+
+## Hosting on Raspberry Pi
+
+A helper script `rpi_server.py` is provided to simplify running the web app on a Raspberry Pi. Specify the desired port as an argument:
+
+```bash
+python rpi_server.py 8080  # runs on http://0.0.0.0:8080/
+```
+
+If no port is given, the default is 5000.

--- a/rpi_server.py
+++ b/rpi_server.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Simple helper script to host the FatBit web application on a Raspberry Pi.
+
+Usage:
+    python rpi_server.py [PORT]
+
+When a PORT is provided, the app will bind to that port on all interfaces
+(`0.0.0.0`). If no port is specified, 5000 is used by default.
+
+This script can be run after installing the requirements with
+```
+pip install -r requirements.txt
+```
+"""
+
+import sys
+
+from webapp import app
+
+
+def main():
+    """Entry point for the Raspberry Pi server runner."""
+    port = 5000
+    if len(sys.argv) > 1:
+        try:
+            # Read port number from the first command line argument
+            port = int(sys.argv[1])
+        except ValueError:
+            print(f"Invalid port: {sys.argv[1]}. Using default {port}.")
+
+    # Run the Flask application accessible on the network
+    # ``host='0.0.0.0'`` exposes it to other machines on the LAN
+    app.run(host="0.0.0.0", port=port, debug=False)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add instructions for hosting on Raspberry Pi in README
- add `rpi_server.py` helper script for running the app with a custom port

## Testing
- `pip install -r requirements.txt`
- `python rpi_server.py 5050` (terminated after startup)

------
https://chatgpt.com/codex/tasks/task_e_6884b2e1c61c8328ba2f22047e83bd83