### PR TITLE
Add ZIP import support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ For more details see [Google's help article](https://support.google.com/fitbit/a
 
 FatBit Web replaces the old PyQt desktop application with a more accessible web interface.
 
+The legacy GUI (`FatBit.py`) now supports loading exported data directly from ZIP
+archives. Use **Load JSON/ZIP Files** and select your Fitbit export to import all
+contained JSON entries automatically.
+
 ## Hosting on Raspberry Pi
 
 A helper script `rpi_server.py` is provided to simplify running the web app on a Raspberry Pi. Specify the desired port as an argument:


### PR DESCRIPTION
## Summary
- handle `.zip` files when loading exported data
- document ZIP support for the legacy GUI

## Testing
- `python -m py_compile FatBit.py webapp.py rpi_server.py`

------
https://chatgpt.com/codex/tasks/task_e_6884f2c4787483289b06f3b453031102